### PR TITLE
Excepts the OPTIONS http method from the @authenticated decorator.

### DIFF
--- a/dorthy/security/core.py
+++ b/dorthy/security/core.py
@@ -12,6 +12,8 @@ from contextlib import contextmanager
 
 from decorator import decorator
 
+from tornado.web import RequestHandler
+
 from dorthy.dp import Singleton, ObjectMap
 from dorthy.json import jsonify
 from dorthy.request import RequestContextManager, RequestContextError
@@ -539,6 +541,10 @@ def authorized(expression=None, arg_name="authentication"):
     object into a method or function that is decorated.
     """
     def _authorized(f, *args, **kwargs):
+
+        # if we're wrapping a HTTP request handler, don't worry about the OPTIONS method
+        if len(args) and isinstance(args[0], RequestHandler) and args[0].request.method == 'OPTIONS':
+            return f(*args, **kwargs)
 
         authorized_attribute = AuthorizedAttribute(f=f, args=args, kwargs=kwargs)
         with authorized_context(expression=expression, authorized_attribute=authorized_attribute) as authentication:

--- a/dorthy/web.py
+++ b/dorthy/web.py
@@ -357,6 +357,11 @@ class TemplateHandler(BaseHandler):
 def authenticated(redirect=False, allow_header_auth=False):
 
     def _authenticated(f, handler, *args, **kwargs):
+
+        if handler.request.method == "OPTIONS":
+            """ Options method should not be authenticated """
+            return f(handler, *args, **kwargs)
+
         if not SecurityManager().authenticated():
             SecurityManager().load_context(handler)
             if not SecurityManager().authenticated():


### PR DESCRIPTION
Before a browser will do a cross-origin POST or PUT, it does an OPTIONS check first.
It won't pass its cookies to the OPTIONS call, so Dorthy can't tell that the client
is in fact authenticated. This stops the browser from issuing any POST requests
to endpoints protected by @authenticated in the case of a cross-origin setup.